### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,27 @@
+export interface Options {
+	/**
+	 * Override the default fallback.
+	 *
+	 * @default `${text} (${url})`
+	 */
+	fallback?: (text: string, url: string) => string;
+}
+
+/**
+ * [Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
+ *
+ * For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
+ *
+ * @param text
+ * @param url
+ * @param options
+ * @returns The string ready for output.
+ */
+export default function terminalLink(text:string, url: string, options?: Options): string;
+
+/**
+ * Check whether the terminal support links.
+ *
+ * Prefer just using the default fallback or the `fallback` option whenever possible.
+ */
+export const isSupported: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,16 +8,12 @@ export interface Options {
 }
 
 /**
+ * Create a clickable link in the terminal
+ *
  * [Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
- *
  * For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
- *
- * @param text
- * @param url
- * @param options
- * @returns The string ready for output.
  */
-export default function terminalLink(text:string, url: string, options?: Options): string;
+export default function terminalLink(text: string, url: string, options?: Options): string;
 
 /**
  * Check whether the terminal support links.

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface Options {
 }
 
 /**
- * Create a clickable link in the terminal
+ * Create a clickable link in the terminal.
  *
  * [Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
  * For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.

--- a/index.js
+++ b/index.js
@@ -10,4 +10,5 @@ module.exports = (text, url, options = {}) => {
 	return ansiEscapes.link(text, url);
 };
 
+module.exports.default = module.exports;
 module.exports.isSupported = supportsHyperlinks.stdout;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,10 @@
 import {expectType} from 'tsd-check';
-import terminalLink from '.';
-import {isSupported} from '.';
+import terminalLink, {isSupported} from '.';
 
-expectType<string>(terminalLink("text", "url"));
-expectType<string>(terminalLink("text", "url", {fallback: (text, url)=> `[${text}](${url})`}));
+expectType<string>(terminalLink('text', 'url'));
+
+expectType<string>(terminalLink('text', 'url', {
+	fallback: (text, url) => `[${text}](${url})`
+}));
 
 expectType<boolean>(isSupported);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,8 @@
+import {expectType} from 'tsd-check';
+import terminalLink from '.';
+import {isSupported} from '.';
+
+expectType<string>(terminalLink("text", "url"));
+expectType<string>(terminalLink("text", "url", {fallback: (text, url)=> `[${text}](${url})`}));
+
+expectType<boolean>(isSupported);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"test": "xo && ava && tsd-check"
 	},
 	"files": [
-		"index.d.ts",
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"link",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
+		"index.d.ts",
 		"index.js"
 	],
 	"keywords": [
@@ -36,6 +37,7 @@
 	"devDependencies": {
 		"ava": "*",
 		"clear-module": "^2.1.0",
+		"tsd-check": "^0.2.1",
 		"xo": "*"
 	}
 }


### PR DESCRIPTION
Fixes #2 

### Style Guide Checklist

- [x] Use tab-indentation and semicolons.
- [x] The definition should target the latest TypeScript version.
- [x] Exported properties/methods should be documented (see below).
- [x] The definition should be tested (see below).
- [x] Ensure you're not falling for any of the [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/#common-mistakes).
- [x] For packages with a default export, use `export default foo;`, not `export = foo;`. You will have to add `module.exports.default = foo;` to the `index.js` file.
- [x] If the entry file in the package is named `index.js`, name the type definition file `index.d.ts` and put it in root.<br>
	You don't need to add a `typings` field to package.json as TypeScript will infer it from the name.
- [x] Add the type definition file to the `files` field in package.json.
- [x] The pull request should have the title `Add TypeScript definition`. *(Copy-paste it so you don't get it wrong)*
- [ ] Ignore any Travis linting failures. I will fix them after merging.
- [ ] Help review [other pull requests](https://github.com/search?q=user%3Asindresorhus+is%3Apr+is%3Aopen+%22Add+TypeScript+definition%22&type=Issues) that adds a type definition.
