### PR TITLE
Add stderr support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace terminalLink {
 
 declare const terminalLink: {
 	/**
-	Create a clickable link in the terminal.
+	Create a clickable link in the terminal's stdout.
 
 	[Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
 	For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
@@ -35,6 +35,34 @@ declare const terminalLink: {
 	Prefer just using the default fallback or the `fallback` option whenever possible.
 	*/
 	readonly isSupported: boolean;
+
+	readonly stderr: {
+		/**
+		Create a clickable link in the terminal's stderr.
+
+		[Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
+		For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
+
+		@param text - Text to linkify.
+		@param url - URL to link to.
+
+		@example
+		```
+		import terminalLink = require('terminal-link');
+
+		const link = terminalLink.stderr('My Website', 'https://sindresorhus.com');
+		console.error(link);
+		```
+		*/
+		(text: string, url: string, options?: terminalLink.Options): string;
+
+		/**
+		Check whether the terminal's stderr support links.
+
+		Prefer just using the default fallback or the `fallback` option whenever possible.
+		*/
+		readonly isSupported: boolean;
+	}
 
 	// TODO: Remove this for the next major release
 	default: typeof terminalLink;

--- a/index.js
+++ b/index.js
@@ -2,14 +2,19 @@
 const ansiEscapes = require('ansi-escapes');
 const supportsHyperlinks = require('supports-hyperlinks');
 
-module.exports = (text, url, options = {}) => {
-	if (!supportsHyperlinks.stdout) {
+const terminalLink = (text, url, options = {}, target = 'stdout') => {
+	if (!supportsHyperlinks[target]) {
 		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
 	}
 
 	return ansiEscapes.link(text, url);
 };
 
+module.exports = (text, url, options = {}) => terminalLink(text, url, options);
+
+module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, options, 'stderr');
+
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;
 module.exports.isSupported = supportsHyperlinks.stdout;
+module.exports.stderr.isSupported = supportsHyperlinks.stderr;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const terminalLink = (text, url, options = {}) => {
 
 module.exports = (text, url, options = {}) => terminalLink(text, url, options);
 
-module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, {target: 'stderr', ...options});
+module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, options);
 
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -2,8 +2,12 @@
 const ansiEscapes = require('ansi-escapes');
 const supportsHyperlinks = require('supports-hyperlinks');
 
-const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
-	if (!supportsHyperlinks[target]) {
+const terminalLink = (text, url, options = {}) => {
+	if (typeof options.target === 'undefined') {
+		options.target = 'stdout';
+	}
+
+	if (!supportsHyperlinks[options.target]) {
 		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
 	}
 

--- a/index.js
+++ b/index.js
@@ -2,12 +2,8 @@
 const ansiEscapes = require('ansi-escapes');
 const supportsHyperlinks = require('supports-hyperlinks');
 
-const terminalLink = (text, url, options = {}) => {
-	if (typeof options.target === 'undefined') {
-		options.target = 'stdout';
-	}
-
-	if (!supportsHyperlinks[options.target]) {
+const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
+	if (!supportsHyperlinks[target]) {
 		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
 	}
 
@@ -16,7 +12,7 @@ const terminalLink = (text, url, options = {}) => {
 
 module.exports = (text, url, options = {}) => terminalLink(text, url, options);
 
-module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, options);
+module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, {target: 'stderr', ...options});
 
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const ansiEscapes = require('ansi-escapes');
 const supportsHyperlinks = require('supports-hyperlinks');
 
-const terminalLink = (text, url, options = {}, target = 'stdout') => {
+const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
 	if (!supportsHyperlinks[target]) {
 		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
 	}
@@ -12,7 +12,7 @@ const terminalLink = (text, url, options = {}, target = 'stdout') => {
 
 module.exports = (text, url, options = {}) => terminalLink(text, url, options);
 
-module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, options, 'stderr');
+module.exports.stderr = (text, url, options = {}) => terminalLink(text, url, {target: 'stderr', ...options});
 
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,3 +10,15 @@ expectType<string>(
 );
 
 expectType<boolean>(terminalLink.isSupported);
+
+// stderr
+
+expectType<string>(terminalLink.stderr('text', 'url'));
+
+expectType<string>(
+	terminalLink.stderr('text', 'url', {
+		fallback: (text, url) => `[${text}](${url})`
+	})
+);
+
+expectType<boolean>(terminalLink.stderr.isSupported)

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ console.log(link);
 
 ### terminalLink(text, url, [options])
 
+Create a link for use in stdout.
+
 [Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
 
 For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
@@ -56,10 +58,43 @@ Override the default fallback. The function receives the `text` and `url` as par
 
 Type: `boolean`
 
-Check whether the terminal support links.
+Check whether the terminal's stdout supports links.
 
 Prefer just using the default fallback or the `fallback` option whenever possible.
 
+### terminalLink.stderr(text, url, [options])
+
+Create a link for use in stdout.
+
+#### text
+
+Type: `string`
+
+Text to linkify.
+
+#### url
+
+Type: `string`
+
+URL to link to.
+
+#### options
+
+Type: `Object`
+
+##### fallback
+
+Type: `Function`
+
+Override the default fallback. The function receives the `text` and `url` as parameters and is expected to return a string.
+
+### terminalLink.stderr.isSupported
+
+Type: `boolean`
+
+Check whether the terminal's stderr supports links.
+
+Prefer just using the default fallback or the `fallback` option whenever possible.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -18,11 +18,29 @@ test('main', t => {
 	t.is(actual, '\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007');
 });
 
+test('stderr', t => {
+	process.env.FORCE_HYPERLINK = 1;
+	const m = require('.');
+
+	const actual = m.stderr('My Website', 'https://sindresorhus.com');
+	console.log(actual);
+	t.is(actual, '\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007');
+});
+
 test('default fallback', t => {
 	process.env.FORCE_HYPERLINK = 0;
 	const m = require('.');
 
 	const actual = m('My Website', 'https://sindresorhus.com');
+	console.log(actual);
+	t.is(actual, 'My Website (https://sindresorhus.com)');
+});
+
+test('stderr default fallback', t => {
+	process.env.FORCE_HYPERLINK = 0;
+	const m = require('.');
+
+	const actual = m.stderr('My Website', 'https://sindresorhus.com');
 	console.log(actual);
 	t.is(actual, 'My Website (https://sindresorhus.com)');
 });
@@ -38,7 +56,23 @@ test('custom fallback', t => {
 	t.is(actual, 'My Website: https://sindresorhus.com');
 });
 
+test('custom fallback stderr', t => {
+	process.env.FORCE_HYPERLINK = 0;
+	const m = require('.');
+
+	const actual = m.stderr('My Website', 'https://sindresorhus.com', {
+		fallback: (text, url) => `${text}: ${url}`
+	});
+	console.log(actual);
+	t.is(actual, 'My Website: https://sindresorhus.com');
+});
+
 test('isSupported', t => {
 	const m = require('.');
 	t.is(typeof m.isSupported, 'boolean');
+});
+
+test('isSupported stderr', t => {
+	const m = require('.');
+	t.is(typeof m.stderr.isSupported, 'boolean');
 });

--- a/test.js
+++ b/test.js
@@ -42,7 +42,7 @@ test('stderr default fallback', t => {
 
 	const actual = m.stderr('My Website', 'https://sindresorhus.com');
 	console.log(actual);
-	t.is(actual, 'My Website (https://sindresorhus.com)');
+	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
 });
 
 test('custom fallback', t => {


### PR DESCRIPTION
Closes #4 and replaces PR #5 (apologies for messing up the previous PR, my git skills are somewhat lacking)

This PR allows you to do the following:

```javascript
// stdout
terminalLink('Google', 'https://google.com');
terminalLink.isSupported;

// stderr
terminalLink.stderr('Google', 'https://google.com');
terminalLink.stderr.isSupported;
```