### PR TITLE
Add whitespace to fallback output so the URL is linkified

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const supportsHyperlinks = require('supports-hyperlinks');
 
 module.exports = (text, url, options = {}) => {
 	if (!supportsHyperlinks.stdout) {
-		return options.fallback ? options.fallback(text, url) : `${text} ( ${url} )`;
+		return options.fallback ? options.fallback(text, url) : `${text} (\u200B${url}\u200B)`;
 	}
 
 	return ansiEscapes.link(text, url);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const supportsHyperlinks = require('supports-hyperlinks');
 
 module.exports = (text, url, options = {}) => {
 	if (!supportsHyperlinks.stdout) {
-		return options.fallback ? options.fallback(text, url) : `${text} (${url})`;
+		return options.fallback ? options.fallback(text, url) : `${text} ( ${url} )`;
 	}
 
 	return ansiEscapes.link(text, url);

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ test('default fallback', t => {
 
 	const actual = m('My Website', 'https://sindresorhus.com');
 	console.log(actual);
-	t.is(actual, 'My Website (https://sindresorhus.com)');
+	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
 });
 
 test('custom fallback', t => {


### PR DESCRIPTION
This should make links in fallback terminals still clickable. Previously they [appended a closing paren](https://github.com/sindresorhus/terminal-link/issues/11).