### PR TITLE
Add `fallback: false` option to disable the fallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 declare namespace terminalLink {
 	interface Options {
 		/**
-		Override the default fallback.
+		Override the default fallback. If false, the fallback will be disabled.
 
 		@default `${text} (${url})`
 		*/
-		fallback?: (text: string, url: string) => string;
+		fallback?: ((text: string, url: string) => string) | false;
 	}
 }
 
@@ -14,7 +14,8 @@ declare const terminalLink: {
 	Create a clickable link in the terminal's stdout.
 
 	[Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
-	For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
+	For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`,
+	unless the fallback is disabled by setting the `fallback` option to `false`.
 
 	@param text - Text to linkify.
 	@param url - URL to link to.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,11 @@ const supportsHyperlinks = require('supports-hyperlinks');
 
 const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
 	if (!supportsHyperlinks[target]) {
+		// If the fallback has been explicitly disabled, don't modify the text itself.
+		if (options.fallback === false) {
+			return text;
+		}
+
 		return options.fallback ? options.fallback(text, url) : `${text} (\u200B${url}\u200B)`;
 	}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,6 +9,12 @@ expectType<string>(
 	})
 );
 
+expectType<string>(
+	terminalLink('text', 'url', {
+		fallback: false
+	})
+);
+
 expectType<boolean>(terminalLink.isSupported);
 
 // stderr

--- a/readme.md
+++ b/readme.md
@@ -50,9 +50,11 @@ Type: `object`
 
 ##### fallback
 
-Type: `Function`
+Type: `Function | false`
 
 Override the default fallback. The function receives the `text` and `url` as parameters and is expected to return a string.
+
+If set to `false`, the fallback will be disabled when a terminal is unsupported.
 
 ### terminalLink.isSupported
 

--- a/test.js
+++ b/test.js
@@ -36,6 +36,17 @@ test('default fallback', t => {
 	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
 });
 
+test('disabled fallback', t => {
+	process.env.FORCE_HYPERLINK = 0;
+	const terminalLink = require('.');
+
+	const actual = terminalLink('My Website', 'https://sindresorhus.com', {
+		fallback: false
+	});
+	console.log(actual);
+	t.is(actual, 'My Website');
+});
+
 test('stderr default fallback', t => {
 	process.env.FORCE_HYPERLINK = 0;
 	const terminalLink = require('.');


### PR DESCRIPTION
This PR updates `terminal-link` to support disabling the fallback entirely and updates the TS types and documentation to reflect this change.

This PR enables us to update `ink-link` to support disabling the fallback with an option:
- https://github.com/sindresorhus/ink-link/issues/4
- https://github.com/sindresorhus/ink-link/pull/5/files

Original request: https://github.com/sindresorhus/ink-link/pull/5/files#r326882650