### PR TITLE
Allow `fallback` to be `true`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare namespace terminalLink {
 
 		@default `${text} (${url})`
 		*/
-		fallback?: ((text: string, url: string) => string) | false;
+		fallback?: ((text: string, url: string) => string) | boolean;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
 			return text;
 		}
 
-		return options.fallback ? options.fallback(text, url) : `${text} (\u200B${url}\u200B)`;
+		return typeof options.fallback === 'function' ? options.fallback(text, url) : `${text} (\u200B${url}\u200B)`;
 	}
 
 	return ansiEscapes.link(text, url);

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Type: `object`
 
 ##### fallback
 
-Type: `Function | false`
+Type: `Function | boolean`
 
 Override the default fallback. The function receives the `text` and `url` as parameters and is expected to return a string.
 

--- a/test.js
+++ b/test.js
@@ -47,6 +47,17 @@ test('disabled fallback', t => {
 	t.is(actual, 'My Website');
 });
 
+test('explicitly enabled fallback', t => {
+	process.env.FORCE_HYPERLINK = 0;
+	const terminalLink = require('.');
+
+	const actual = terminalLink('My Website', 'https://sindresorhus.com', {
+		fallback: true
+	});
+	console.log(actual);
+	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
+});
+
 test('stderr default fallback', t => {
 	process.env.FORCE_HYPERLINK = 0;
 	const terminalLink = require('.');


### PR DESCRIPTION
This is a follow-up PR to: https://github.com/sindresorhus/terminal-link/pull/13

In that PR, `fallback` could only be a function or `false`. If it was set to `true`, it would produce an error because it would attempt to execute it as if it was a function:

```
  Error thrown in test:

  TypeError {
    message: 'options.fallback is not a function',
  }
```

This means that [upstream consumers would need to replace `fallback=true` with `fallback=undefined`](https://github.com/sindresorhus/ink-link/pull/5/commits/6bad68c11fb0c6c82c67da487885d3aef76609b1), which isn't a great experience.

This PR just updates `terminal-link` to produce the default fallback if `fallback=true`, and updates the associated documentation.