### PR TITLE
feat(index.js fallback): added surrounding space for not supported terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const terminalLink = (text, url, {target = 'stdout', ...options} = {}) => {
 			return text;
 		}
 
-		return typeof options.fallback === 'function' ? options.fallback(text, url) : `${text} (\u200B${url}\u200B)`;
+		// Wrap it in spaces so it doesn't use the closing parenthesis as part of the link
+		return typeof options.fallback === 'function' ? options.fallback(text, url) : `${text} (\u200B ${url} \u200B)`;
 	}
 
 	return ansiEscapes.link(text, url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "terminal-link",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Create clickable links in the terminal",
 	"license": "MIT",
 	"repository": "sindresorhus/terminal-link",

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ test('default fallback', t => {
 
 	const actual = terminalLink('My Website', 'https://sindresorhus.com');
 	console.log(actual);
-	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
+	t.is(actual, 'My Website (\u200B https://sindresorhus.com \u200B)');
 });
 
 test('disabled fallback', t => {
@@ -55,7 +55,7 @@ test('explicitly enabled fallback', t => {
 		fallback: true
 	});
 	console.log(actual);
-	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
+	t.is(actual, 'My Website (\u200B https://sindresorhus.com \u200B)');
 });
 
 test('stderr default fallback', t => {
@@ -64,7 +64,7 @@ test('stderr default fallback', t => {
 
 	const actual = terminalLink.stderr('My Website', 'https://sindresorhus.com');
 	console.log(actual);
-	t.is(actual, 'My Website (\u200Bhttps://sindresorhus.com\u200B)');
+	t.is(actual, 'My Website (\u200B https://sindresorhus.com \u200B)');
 });
 
 test('custom fallback', t => {


### PR DESCRIPTION
In unsupported terminals, the closing parenthesis is being taken as part of the link, see VSCode and WebStorm

Related issues:

#11 #8 #1