### PR TITLE
docs(readme): clarify behaviour of `fallback: false`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Create a link for use in stdout.
 
 [Supported terminals.](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
 
-For unsupported terminals, the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
+For unsupported terminals, by default the link will be printed in parens after the text: `My website (https://sindresorhus.com)`.
 
 #### text
 
@@ -51,7 +51,7 @@ Type: `Function | boolean`
 
 Override the default fallback. The function receives the `text` and `url` as parameters and is expected to return a string.
 
-If set to `false`, the fallback will be disabled when a terminal is unsupported.
+If set to `false`, the `text` will be returned as-is when a terminal is unsupported.
 
 ### terminalLink.isSupported
 


### PR DESCRIPTION
I was about to open an issue asking if you'd accept a PR to allow a way to do this, but upon taking a look at the source I realized what I was looking for is [exactly what `fallback: false` already does](https://github.com/sindresorhus/terminal-link/blob/1fa2892d27f388ea1cf9a2c934470fc94dda2115/index.js#L6-L9), despite being documented as "disabling the fallback", which is rather misleading.